### PR TITLE
Expand currency list to all major currencies

### DIFF
--- a/run.php
+++ b/run.php
@@ -33,7 +33,7 @@ include 'vendor/autoload.php';
 
 $timezone   = 'Europe/Amsterdam';
 $logLevel   = Level::Debug;
-$currencies = ['EUR', 'HUF', 'GBP', 'UAH', 'PLN', 'TRY', 'DKK', 'USD', 'BRL', 'CAD', 'MXN', 'IDR', 'AUD', 'NZD', 'EGP', 'MAD', 'ZAR', 'JPY', 'CNY', 'RUB', 'INR', 'ILS', 'CHF', 'HRK'];
+$currencies = ['EUR', 'HUF', 'GBP', 'UAH', 'PLN', 'TRY', 'DKK', 'USD', 'BRL', 'CAD', 'MXN', 'IDR', 'AUD', 'NZD', 'EGP', 'MAD', 'ZAR', 'JPY', 'CNY', 'RUB', 'INR', 'ILS', 'CHF', 'HRK', 'HKD', 'SEK', 'KRW', 'SGD', 'NOK', 'TWD', 'THB', 'CZK', 'CLP', 'PHP', 'AED', 'COP', 'SAR', 'MYR', 'RON'];
 $handler    = new StreamHandler('php://stdout', $logLevel);
 $formatter  = new LineFormatter(null, null, false, true);
 $log        = new Logger('exchange-rates');


### PR DESCRIPTION
<!--
Before you create a new PR, please consider:

1) Pull requests for the MAIN branch will be closed.
2) DO NOT include translations in your PR. Only English US sentences.

Thanks.
-->

Changes in this pull request:

- Expand the list of currencies to include all most traded currencies listed in [https://en.wikipedia.org/wiki/Template:Most_traded_currencies](https://en.wikipedia.org/wiki/Template:Most_traded_currencies). New currencies added in this PR and their share in international trade are:

| Rank | Currency          | ISO 4217 code | Proportion of daily volume, April 2019 |
|------|-------------------|---------------|----------------------------------------|
| 9    | Hong Kong dollar  | HKD           | 3.5%                                   |
| 11   | Swedish krona     | SEK           | 2.0%                                   |
| 12   | South Korean won  | KRW           | 2.0%                                   |
| 13   | Singapore dollar  | SGD           | 1.8%                                   |
| 14   | Norwegian krone   | NOK           | 1.8%                                   |
| 21   | New Taiwan dollar | TWD           | 0.9%                                   |
| 24   | Thai baht         | THB           | 0.5%                                   |
| 27   | Czech koruna      | CZK           | 0.4%                                   |
| 29   | Chilean peso      | CLP           | 0.3%                                   |
| 30   | Philippine peso   | PHP           | 0.3%                                   |
| 31   | UAE dirham        | AED           | 0.2%                                   |
| 32   | Colombian peso    | COP           | 0.2%                                   |
| 33   | Saudi riyal       | SAR           | 0.2%                                   |
| 34   | Malaysian ringgit | MYR           | 0.1%                                   |
| 35   | Romanian leu      | RON           | 0.1%                                   |

@JC5 I understand we stopped accepting new currency to Firefly III as user may create one by himself. However, since the collected exchange rate data has to be downloaded from Azure, a user-added currency can't be _created_ by user. Hence, it would be ideal to expand the currency coverage to major currencies that are not on the default currency table.